### PR TITLE
Fix some issues reported during review

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -31,7 +31,6 @@
         "https://*/*",
         "messagesRead",
         "accountsRead",
-        "clipboardWrite",
-        "webRequest"
+        "clipboardWrite"
     ]
 }

--- a/popup.js
+++ b/popup.js
@@ -1,159 +1,164 @@
 browser.tabs.query({
 	active: true,
 	currentWindow: true,
-}).then(tabs => {
-	browser.messageDisplay.getDisplayedMessage(tabs[0].id).then(message => {
-		browser.messages.getFull(message.id).then(fullMessage => {
-			console.log(fullMessage)
-			const headers = fullMessage.headers
-			const messageEl = document.getElementById('message')
-			const actionContainerEl = document.getElementById('action-container')
+}).then(handleActiveTabs)
+	
+async function handleActiveTabs(tabs) {
+	let message = await browser.messageDisplay.getDisplayedMessage(tabs[0].id);
+	let fullMessage = await browser.messages.getFull(message.id);
+	
+	const headers = fullMessage.headers
+	const messageEl = document.getElementById('message')
+	const actionContainerEl = document.getElementById('action-container')
 
-			if (!headers.hasOwnProperty('list-unsubscribe')) {
-				messageEl.innerText = browser.i18n.getMessage('noUnsub')
-				return
+	if (!headers.hasOwnProperty('list-unsubscribe')) {
+		messageEl.innerText = browser.i18n.getMessage('noUnsub')
+		return
+	}
+
+	let unsubEmail = null
+	let unsubLink = null
+	headers['list-unsubscribe'][0].split(',').forEach(link => {
+		let result
+		if (result = link.match(/^\s*<(mailto:.+)>/)) {
+			unsubEmail = result[1]
+			return
+		}
+		if (result = link.match(/^\s*<(https?:\/\/.+)>/)) {
+			unsubLink = result[1]
+			return
+		}
+	})
+
+	// validate link
+	if (unsubLink !== null) {
+		try {
+			unsubLink = new URL(unsubLink)
+		} catch (e) {
+			console.warn(e)
+			unsubLink = null
+		}
+	}
+
+	// validate and prepare email
+	let unsubEmailSubject = null
+	if (unsubEmail !== null) {
+		try {
+			unsubEmail = new URL(unsubEmail)
+
+			// extract subject
+			if (unsubEmail.searchParams.has('subject')) {
+				unsubEmailSubject = unsubEmail.searchParams.get('subject')
 			}
 
-			let unsubEmail = null
-			let unsubLink = null
-			headers['list-unsubscribe'][0].split(',').forEach(link => {
-				let result
-				if (result = link.match(/^\s*<(mailto:.+)>/)) {
-					unsubEmail = result[1]
-					return
-				}
-				if (result = link.match(/^\s*<(https?:\/\/.+)>/)) {
-					unsubLink = result[1]
-					return
+			unsubEmail = unsubEmail.pathname
+
+			if (!unsubEmail.match(/^[^@]+@[^@]+$/)) {
+				console.warn('invalid email address', unsubEmail)
+				unsubEmail = null
+			}
+		} catch (e) {
+			console.warn(e)
+			unsubEmail = null
+		}
+	}
+
+	if (unsubLink === null && unsubEmail === null) {
+		messageEl.innerText = browser.i18n.getMessage('noUnsub')
+		console.error('no valid unsubscribe link or email found')
+		return
+	}
+
+	// check if RFC 8058 is supported
+	let unsubCommand = null
+	if (headers.hasOwnProperty('list-unsubscribe-post')) {
+		unsubCommand = headers['list-unsubscribe-post'][0]
+	}
+
+	console.log('unsub link: ', unsubLink)
+	console.log('unsub email: ', unsubEmail)
+	console.log('unsub command: ', unsubCommand)
+
+	messageEl.innerText = browser.i18n.getMessage('unsubConfirmPrompt')
+	if (unsubLink !== null) {
+		const linkContainerEl = document.getElementById('unsub-link-container')
+		const linkEl = document.createElement('code')
+		linkEl.innerText = unsubLink
+		linkEl.addEventListener('click', () => {
+			navigator.clipboard.writeText(linkEl.innerText)
+		})
+
+		linkContainerEl.innerText = browser.i18n.getMessage('unsubLink')
+		linkContainerEl.appendChild(linkEl)
+
+		if (unsubCommand) {
+			const button = document.createElement('button')
+			button.innerText = browser.i18n.getMessage('confirmOneClick')
+			button.addEventListener('click', async () => {
+				linkContainerEl.style.display = 'none'
+				actionContainerEl.style.display = 'none'
+				messageEl.innerText = browser.i18n.getMessage('oneClickInProgress')
+
+				try {
+					await fetch(unsubLink, {
+						method: 'POST',
+						body: unsubCommand,
+					});
+					messageEl.innerText = browser.i18n.getMessage(
+						'oneClickSuccess'
+					);
+				} catch (e) {
+					messageEl.innerText = browser.i18n.getMessage(
+						'oneClickFailure', 
+						e.message
+					);
 				}
 			})
 
-			// validate link
-			if (unsubLink !== null) {
-				try {
-					unsubLink = new URL(unsubLink)
-				} catch (e) {
-					console.warn(e)
-					unsubLink = null
-				}
-			}
+			actionContainerEl.appendChild(button)
+		}
 
-			// validate and prepare email
-			let unsubEmailSubject = null
-			if (unsubEmail !== null) {
-				try {
-					unsubEmail = new URL(unsubEmail)
-
-					// extract subject
-					if (unsubEmail.searchParams.has('subject')) {
-						unsubEmailSubject = unsubEmail.searchParams.get('subject')
-					}
-
-					unsubEmail = unsubEmail.pathname
-
-					if (!unsubEmail.match(/^[^@]+@[^@]+$/)) {
-						console.warn('invalid email address', unsubEmail)
-						unsubEmail = null
-					}
-				} catch (e) {
-					console.warn(e)
-					unsubEmail = null
-				}
-			}
-
-			if (unsubLink === null && unsubEmail === null) {
-				messageEl.innerText = browser.i18n.getMessage('noUnsub')
-				console.error('no valid unsubscribe link or email found')
-				return
-			}
-
-			// check if RFC 8058 is supported
-			let unsubCommand = null
-			if (headers.hasOwnProperty('list-unsubscribe-post')) {
-				unsubCommand = headers['list-unsubscribe-post'][0]
-			}
-
-			console.log('unsub link: ', unsubLink)
-			console.log('unsub email: ', unsubEmail)
-			console.log('unsub command: ', unsubCommand)
-
-			messageEl.innerText = browser.i18n.getMessage('unsubConfirmPrompt')
-			if (unsubLink !== null) {
-				const linkContainerEl = document.getElementById('unsub-link-container')
-				const linkEl = document.createElement('code')
-				linkEl.innerText = unsubLink
-				linkEl.addEventListener('click', () => {
-					navigator.clipboard.writeText(linkEl.innerText)
-				})
-
-				linkContainerEl.innerText = browser.i18n.getMessage('unsubLink')
-				linkContainerEl.appendChild(linkEl)
-
-				if (unsubCommand) {
-					const button = document.createElement('button')
-					button.innerText = browser.i18n.getMessage('confirmOneClick')
-					button.addEventListener('click', async () => {
-						linkContainerEl.style.display = 'none'
-						actionContainerEl.style.display = 'none'
-						messageEl.innerText = browser.i18n.getMessage('oneClickInProgress')
-
-
-						fetch(unsubLink, {
-							method: 'POST',
-							body: unsubCommand,
-						}).then(() => {
-							messageEl.innerText = browser.i18n.getMessage('oneClickSuccess')
-						}).catch((e) => {
-							messageEl.innerText = browser.i18n.getMessage('oneClickFailure', e.message)
-						})
-					})
-
-					actionContainerEl.appendChild(button)
-				}
-
-				const button = document.createElement('button')
-				button.innerText = browser.i18n.getMessage('confirmOpenLink')
-				button.addEventListener('click', () => {
-					browser.tabs.create({
-						url: unsubLink.toString(),
-					})
-				})
-				actionContainerEl.appendChild(button)
-			}
-
-			if (unsubEmail !== null) {
-				const button = document.createElement('button')
-				button.innerText = browser.i18n.getMessage('confirmComposeEmail')
-				button.addEventListener('click', async () => {
-					const identityId = await (async (message) => {
-						// try to get identityId from the message
-						if (typeof message.folder === 'Object') {
-							const identities = await messenger.accounts.get(message.folder.accountId).identities
-							// we can use it only if there is only one identity
-							if (identities.length === 1) {
-								return identities[0].id
-							}
-						}
-
-						// try match email address to identity
-						const identities = await messenger.identities.list()
-						const matching = identities.find(identity => message.recipients.some(email => identity.email === email))
-						if (matching === undefined) {
-							console.warn('no matching identity found, using default')
-							return identities[0].id
-						}
-
-						return matching.id
-
-					})(message)
-					browser.compose.beginNew({
-						to: unsubEmail,
-						subject: unsubEmailSubject ?? 'unsubscribe',
-						identityId,
-					})
-				})
-				actionContainerEl.appendChild(button)
-			}
+		const button = document.createElement('button')
+		button.innerText = browser.i18n.getMessage('confirmOpenLink')
+		button.addEventListener('click', () => {
+			browser.tabs.create({
+				url: unsubLink.toString(),
+			})
 		})
-	})
-})
+		actionContainerEl.appendChild(button)
+	}
+
+	if (unsubEmail !== null) {
+		const button = document.createElement('button')
+		button.innerText = browser.i18n.getMessage('confirmComposeEmail')
+		button.addEventListener('click', async () => {
+			const identityId = await (async (message) => {
+				// try to get identityId from the message
+				if (typeof message.folder === 'Object') {
+					const identities = await messenger.accounts.get(message.folder.accountId).identities
+					// we can use it only if there is only one identity
+					if (identities.length === 1) {
+						return identities[0].id
+					}
+				}
+
+				// try match email address to identity
+				const identities = await messenger.identities.list()
+				const matching = identities.find(identity => message.recipients.some(email => identity.email === email))
+				if (matching === undefined) {
+					console.warn('no matching identity found, using default')
+					return identities[0].id
+				}
+
+				return matching.id
+
+			})(message)
+			browser.compose.beginNew({
+				to: unsubEmail,
+				subject: unsubEmailSubject ?? 'unsubscribe',
+				identityId,
+			})
+		})
+		actionContainerEl.appendChild(button)
+	}
+}

--- a/popup.js
+++ b/popup.js
@@ -128,7 +128,7 @@ browser.tabs.query({
 					const identityId = await (async (message) => {
 						// try to get identityId from the message
 						if (typeof message.folder === 'Object') {
-							const identities = await messanger.accounts.get(message.folder.accountId).identities
+							const identities = await messenger.accounts.get(message.folder.accountId).identities
 							// we can use it only if there is only one identity
 							if (identities.length === 1) {
 								return identities[0].id


### PR DESCRIPTION
This is John, the reviewer who rejected your submission for being listed on ATN.

**The main reason this was rejected is the spelling error in `popup.js`: You used `messanger.*` instead of `messenger.*`**

We wanted to prevent this awesome add-on to start off with bad reviews due to this bug. We did not intend to prevent this add-on from being listed on ATN in general.

This PR is filed, because the issue has not been fixed until today, and the add-on is getting traction due to recommendations in reviews of other add-ons.

This PR is also removing the `webRequest` permission, which we still think is not needed.

We also replaced then-chaining syntax by async/await syntax in `popup.js`. Mentioning this in the review was not intended to be perceived as a blocking review request, but as a suggestion. We did not make that perfectly clear in our review, and will improve our wording in future reviews.