### PR TITLE
ensure we send proper form header with rfc8058 request

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -139,7 +139,10 @@ async function handleMessage(message) {
 				messageEl.innerText = browser.i18n.getMessage('oneClickInProgress')
 
 				try {
+					const reqHeaders = new Headers();
+					reqHeaders.append("Content-Type", "application/x-www-form-urlencoded");
 					await fetch(unsubLink, {
+						headers: reqHeaders,
 						method: 'POST',
 						body: unsubCommand,
 					});


### PR DESCRIPTION
The [rfc8058](https://www.rfc-editor.org/rfc/rfc8058) one click unsubscribe request sends "List-Unsubscribe=One-Click" in the body of the request, but since the header is not specified as "application/x-www-form-urlencoded" the body data is not properly delivered.

This PR fixes that problem by adding the header.

It fixes #8 